### PR TITLE
Simplify reference to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,0 @@
-FROM flownative/action-docker-publish-semver:1

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ After a successful run, the action provides your workflow with the following out
 ## Implementation Note
 
 The repository of this action does not contain the actual implementation code. Instead, it's referring to a pre-built
-image in its `Dockerfile` in order to save resources and speed up workflow runs.
+image in order to save resources and speed up workflow runs.
 
 The code of this action can be found [here](https://github.com/flownative/docker-action-docker-publish-semver).
+

--- a/action.yaml
+++ b/action.yaml
@@ -60,7 +60,8 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://flownative/action-docker-publish-semver:1'
 branding:
   icon: 'package'
   color: 'blue'
+


### PR DESCRIPTION
Should save time due to overhead of starting to build an image